### PR TITLE
Change runtime dir and use nbserver.json to get port

### DIFF
--- a/start_notebook
+++ b/start_notebook
@@ -25,22 +25,22 @@ function start_notebook () {
         
     mkdir -p ~/.jupyter_secure
     chmod 777 ~/.jupyter_secure
-    tmpfile=`mktemp -p ~/.jupyter_secure` || exit 1
+    tmpfile=`mktemp -d -p ~/.jupyter_secure` || exit 1
 
     # Make a random ssl token
     jupyter_token=$(openssl rand -hex 16)
 
     # Create the temp config file
-    touch "$tmpfile".py
-    echo "c.NotebookApp.token = '$jupyter_token'" | cat >> "$tmpfile".py
+    touch "${tmpfile}/config.py"
+    echo "c.NotebookApp.token = '$jupyter_token'" | cat >> "${tmpfile}/config.py"
 
     if [ "$start_dir" = "" ]; then
-        echo "c.NotebookApp.notebook_dir = '/home/$USER/'" | cat >> "$tmpfile".py 
+        echo "c.NotebookApp.notebook_dir = '/home/$USER/'" | cat >> "${tmpfile}/config.py"
     else
-        echo "c.NotebookApp.notebook_dir = '$start_dir'" | cat >> "$tmpfile".py
+        echo "c.NotebookApp.notebook_dir = '$start_dir'" | cat >> "${tmpfile}/config.py"
     fi
-    echo "c.NotebookApp.allow_origin = '*'" | cat >> "$tmpfile".py
-    echo "c.NotebookApp.allow_remote_access = True" | cat >> "$tmpfile".py
+    echo "c.NotebookApp.allow_origin = '*'" | cat >> "${tmpfile}/config.py"
+    echo "c.NotebookApp.allow_remote_access = True" | cat >> "${tmpfile}/config.py"
 
     # Give the user the start of their url
     export jupyter_url="https://$api_token.comet-user-content.sdsc.edu?token=$jupyter_token"


### PR DESCRIPTION
Great project, really useful. I noticed the method for getting the port number might be prone to parsing issues. The PR puts all the run configuration into a temporary directory, which includes a 'nbserver-XXXX.json' that contains the port (and other) configuration information. I did not update the other two notebook batch scripts, just the main one.

I also took a page from various workflow managers and put everything into a common temp folder and changed the naming convention a bit.